### PR TITLE
Add multiple locations to info windows

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,12 +50,12 @@ class App extends Component {
     this.getLocation();
   }
 
-  cardClick = (id) => {
-    this.mapItem.setOpenMarker(id);
+  cardClick = (index) => {
+    this.mapItem.setOpenMarker(index);
   }
 
-  scrollToElement = id => {
-    this.resultListItem.scrollToElement(id);
+  scrollToElement = index => {
+    this.resultListItem.scrollToElement(index);
   }
 
   render() {

--- a/src/App.js
+++ b/src/App.js
@@ -12,8 +12,11 @@ class App extends Component {
       orgs: [],
       categories: [],
       tags: [],
-      haveCoords: false
+      haveCoords: false,
+      locationAddressHashTable: []
     }
+
+
     this.callSheets = callSheets.bind(this);
   }
 
@@ -22,10 +25,10 @@ class App extends Component {
       window.navigator.geolocation.getCurrentPosition(
         position => {
           console.log(position)
-          this.setState({ 
+          this.setState({
             position : {
               coordinates : {
-                lat: parseFloat(position.coords.latitude), 
+                lat: parseFloat(position.coords.latitude),
                 lng: parseFloat(position.coords.longitude)
               }
             }
@@ -51,26 +54,29 @@ class App extends Component {
     this.mapItem.setOpenMarker(id);
   }
 
-  clickedMarker = id => {
+  scrollToElement = id => {
     this.resultListItem.scrollToElement(id);
   }
 
   render() {
     const navbarHeight = 56;
 
-    let map = 
+    let map =
       <Map
         center={this.state.position ? this.state.position.coordinates : null}
         organizations={this.state.orgs}
-        clickedMarker={this.clickedMarker}
+        scrollToElement={this.scrollToElement}
         ref={instance => { this.mapItem = instance }}
+        locationAddressHashTable={this.state.locationAddressHashTable}
       />
 
+
     return (
+
       <div>
-        <Header 
-          categories={this.state.categories} 
-          handleEvent={this.callSheets} 
+        <Header
+          categories={this.state.categories}
+          handleEvent={this.callSheets}
           handleFilter={this.callSheets}
         />
         <SplitScreen style={{ top: navbarHeight }}>
@@ -79,11 +85,11 @@ class App extends Component {
           </SplitScreen.StaticPane>
           <SplitScreen.SlidingPane>
             <ResultList
-              haveCoords={this.state.haveCoords} 
-              ref={instance => { this.resultListItem = instance }} 
-              cardClick={this.cardClick} 
-              data={this.state.orgs} 
-              haveCoords={this.state.haveCoords} 
+              haveCoords={this.state.haveCoords}
+              ref={instance => { this.resultListItem = instance }}
+              cardClick={this.cardClick}
+              data={this.state.orgs}
+              haveCoords={this.state.haveCoords}
               currentPos={this.state.position}
             />
           </SplitScreen.SlidingPane>

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -110,7 +110,8 @@ class OrganizationMap extends Component {
           orgRef.isOpen = false;
         }
 
-        if(i == index){
+        //if(this.props.organizations[orgRef.orgs[0]].coordinates){
+          if(i == index){
           orgRef.isOpen = true
           this.setState({
                  center: this.props.organizations[orgRef.orgs[0]].coordinates,
@@ -119,6 +120,7 @@ class OrganizationMap extends Component {
 
           break;
         }
+      //}
 
 
 

--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -17,7 +17,7 @@ class OrganizationCard extends Component {
   }
 
   cardClick= (e) => {
-    console.log("Click");
+    debugger
     this.props.cardClick(e.currentTarget.id);
   }
 
@@ -37,7 +37,7 @@ class OrganizationCard extends Component {
 
     return (
       <div ref="cardRef">
-        <Card className={styles.Card} id={id} onClick={this.cardClick}>
+        <Card className={styles.Card} id={this.props.index} onClick={this.cardClick}>
           <CardBody>
             {website && <span><a href={website}>&#128279;</a></span>}
             <h3 className={styles.CardBody_headline}>{name}</h3>

--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -17,7 +17,6 @@ class OrganizationCard extends Component {
   }
 
   cardClick= (e) => {
-    debugger
     this.props.cardClick(e.currentTarget.id);
   }
 

--- a/src/components/OrganizationMarker.js
+++ b/src/components/OrganizationMarker.js
@@ -9,6 +9,7 @@ export class OrganizationMarker extends Component {
   constructor(props) {
     super(props);
     this.state.open = props.open;
+    this.orgsArray = []
 
   }
 
@@ -20,10 +21,18 @@ export class OrganizationMarker extends Component {
   }
 
 
-  handleClick = (e) => {
 
-    this.props.setOpenMarker(this.props.id)
-    this.props.handleClick(this.props.organization.id)
+
+  scrollToElement = (e) => {
+    this.props.setOpenMarker(this.props.orgIndexes[0])
+    if(this.props.orgIndexes.length == 1){
+      this.props.scrollToElement(this.props.orgIndexes[0])
+    }
+  }
+
+  handleClickOfInfoWindow = (e) => {
+    console.log(e.currentTarget.id)
+    this.props.scrollToElement(e.currentTarget.id)
   }
 
   handleClose = () => {
@@ -31,23 +40,32 @@ export class OrganizationMarker extends Component {
   }
 
   render() {
-    const { organization } = this.props;
+
+    if(this.orgsArray.length == 0){
+      for(var orgIndex of this.props.orgIndexes){
+        this.orgsArray.push([this.props.organizations[orgIndex], orgIndex])
+      }
+    }
 
     return (
       <Marker
         optimize={false}
-        position={organization.coordinates}
-        onClick={this.handleClick}
+        position={this.orgsArray[0][0].coordinates}
+        onClick={this.scrollToElement}
       >
-        {this.state.open &&
+
+      {this.state.open &&
           <InfoWindow onCloseClick={this.handleClose}>
-            <div>
-              <h3>{organization.name}</h3>
-              <div>{organization.location}</div>
-              <div><a href={`tel:${organization.phone}`}>{organization.phone}</a></div>
+              <div>
+                {this.orgsArray.map(([organization, orgIndex])  =>
+                  <div key={organization.id} id={orgIndex} onClick={this.handleClickOfInfoWindow}>
+                    <h3>{organization.name}</h3>
+                    <div>{organization.location}</div>
+                    <div><a href={`tel:${organization.phone}`}>{organization.phone}</a></div>
+                 </div>)}
             </div>
-          </InfoWindow>
-        }
+          </InfoWindow> }
+
       </Marker>
     );
   }

--- a/src/components/OrganizationMarker.js
+++ b/src/components/OrganizationMarker.js
@@ -31,7 +31,6 @@ export class OrganizationMarker extends Component {
   }
 
   handleClickOfInfoWindow = (e) => {
-    console.log(e.currentTarget.id)
     this.props.scrollToElement(e.currentTarget.id)
   }
 

--- a/src/components/ResultList.js
+++ b/src/components/ResultList.js
@@ -24,7 +24,7 @@ export class ResultList extends Component {
   }
 
   scrollToElement = (id) => {
-    this.refs[id].getRef()
+    this.refs[parseInt(index) + 1].getRef()
   }
 
   getCloserResource = (a , b) => {
@@ -74,21 +74,30 @@ export class ResultList extends Component {
     return(
       <div >
         <div className={styles.results} ref={this.listRef}>
-        <SortBar 
+<<<<<<< HEAD
+        <SortBar
           onSortChange={this.handleSortChange}
           sortOptions={sortOptions}
           haveCoords={this.props.haveCoords}
         />
-        {sortedData.map((org, i) => 
-          <OrganizationCard 
-            key={org.id} 
-            ref={org.id} 
-            cardClick={this.props.cardClick} 
-            organization={org} 
-            haveCoords={this.props.haveCoords} 
+        {sortedData.map((org, i) =>
+          <OrganizationCard
+            key={org.id}
+            ref={org.id}
+            cardClick={this.props.cardClick}
+            organization={org}
+            haveCoords={this.props.haveCoords}
             currentPos={this.props.currentPos}
-          /> 
+          />
         )}
+=======
+        <SortBar
+              sortByDistance={this.props.sortByDistance}
+              sortByAlphabet={this.props.sortByAlphabet}
+              haveCoords={this.props.haveCoords}
+            />
+          { this.props.data.map((org, index) => <OrganizationCard key={org.id} index={index} ref={org.id} cardClick={this.props.cardClick} organization={org} haveCoords={this.props.haveCoords} currentPos={this.props.currentPos}/> ) }
+>>>>>>> Add multiple location to a single info window.
         </div>
 
       </div>

--- a/src/components/ResultList.js
+++ b/src/components/ResultList.js
@@ -43,11 +43,11 @@ export class ResultList extends Component {
   }
 
   sortByAlphabet = () => {
-    return this.props.data.sort(this.getCloserName);
+    return this.props.data.slice().sort(this.getCloserName);
   }
 
   sortByDistance = () => {
-    return this.props.data.sort(this.getCloserResource);
+    return this.props.data.slice().sort(this.getCloserResource);
   }
 
   handleSortChange = (newSort) => {
@@ -56,6 +56,18 @@ export class ResultList extends Component {
         // Set the dataSort variable to whichever sort function is chosen
         dataSort: newSort,
       })
+  }
+
+  cardClick = (id) => {
+    debugger
+    var index = this.props.data.findIndex( org => {
+      if(org.id == id){
+        return true;
+      }
+    })
+
+    this.props.cardClick(index)
+
   }
 
   render() {
@@ -85,8 +97,8 @@ export class ResultList extends Component {
           <OrganizationCard
             key={org.id}
             ref={org.id}
-            index={index}
-            cardClick={this.props.cardClick}
+            index={org.id}
+            cardClick={this.cardClick}
             organization={org}
             haveCoords={this.props.haveCoords}
             currentPos={this.props.currentPos}

--- a/src/components/ResultList.js
+++ b/src/components/ResultList.js
@@ -23,7 +23,7 @@ export class ResultList extends Component {
     this.listRef = React.createRef()
   }
 
-  scrollToElement = (id) => {
+  scrollToElement = (index) => {
     this.refs[parseInt(index) + 1].getRef()
   }
 
@@ -74,30 +74,24 @@ export class ResultList extends Component {
     return(
       <div >
         <div className={styles.results} ref={this.listRef}>
-<<<<<<< HEAD
         <SortBar
           onSortChange={this.handleSortChange}
           sortOptions={sortOptions}
           haveCoords={this.props.haveCoords}
         />
-        {sortedData.map((org, i) =>
+        {
+          sortedData.map((org, index) =>
+
           <OrganizationCard
             key={org.id}
             ref={org.id}
+            index={index}
             cardClick={this.props.cardClick}
             organization={org}
             haveCoords={this.props.haveCoords}
             currentPos={this.props.currentPos}
           />
         )}
-=======
-        <SortBar
-              sortByDistance={this.props.sortByDistance}
-              sortByAlphabet={this.props.sortByAlphabet}
-              haveCoords={this.props.haveCoords}
-            />
-          { this.props.data.map((org, index) => <OrganizationCard key={org.id} index={index} ref={org.id} cardClick={this.props.cardClick} organization={org} haveCoords={this.props.haveCoords} currentPos={this.props.currentPos}/> ) }
->>>>>>> Add multiple location to a single info window.
         </div>
 
       </div>

--- a/src/data/sheetLoadingHelpers.js
+++ b/src/data/sheetLoadingHelpers.js
@@ -21,6 +21,11 @@ function normalizeHeaders(element) {
 
 }
 
+function createMarkerId({lat, lng}){
+  //console.log('createMarkerId ',  lat.toString(), lng.toString())
+  return lat.toString() + lng.toString();
+}
+
 export function callSheets(selected = "", filterType = "") {
   let filter_criteria_list = [];
   let filtered_json = {};
@@ -47,7 +52,7 @@ export function callSheets(selected = "", filterType = "") {
 
       if (selected.length > 0 && filterType == "category") {
         filter_criteria_list = update_criteria(selected, filter_criteria_list);
-      }        
+      }
 
       filtered_json = filter_criteria_list.length <= 0 ? data : find_in_object(JSON.parse(my_json), { categoryautosortscript: filter_criteria_list });
 
@@ -63,7 +68,26 @@ export function callSheets(selected = "", filterType = "") {
 
       //console.log(filtered_json)
 
+
+      //This creates a hash table based for the lat and long of each loction.
+      //This allows us to group all organizations at the same location together. 
+      var locationAddressHashTable = {};
+
+      Object.entries(filtered_json).forEach(([index,  org]) =>{
+
+      if(org.coordinates){
+
+        if(locationAddressHashTable.hasOwnProperty(createMarkerId(org.coordinates))){
+
+            locationAddressHashTable[createMarkerId(org.coordinates)]['orgs'].push(index)
+
+      } else {
+          locationAddressHashTable[createMarkerId(org.coordinates)] = {'orgs': [index] , isOpen: false }
+      }
+      }})
+
       this.setState({
+        locationAddressHashTable : locationAddressHashTable,
         orgs: filtered_json,
         categories: categoryList,
         tags: Object.keys(tags)


### PR DESCRIPTION
This pull request addresses issue #67. 

**Details** 

This pull request creates a hash table with the lat and long as the key and the array index of each organization at that location. This allows us to group each organization that has the same location together. 

**Issues with this PR**

On [Line 53 ](https://github.com/codeforboston/communityconnect/compare/master...microcat49:add_multiple_locations_to_info_windows?expand=1#diff-4c24556a349ad08d5e8789f8f459f786R61) the function cardClick takes ID of the org and loops over the array to find the corresponding index of that organization array entry. This is an issue because looping over the array for every card click could slow down the responsiveness of the application. Although this could be solved in issue #93 by providing a hash table. 

