### PR TITLE
Fix for organization click issues (closes #104)

### DIFF
--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -13,7 +13,9 @@ class OrganizationCard extends Component {
   }
 
   getRef = () => {
-    this.refs.cardRef.scrollIntoView({block: "center", inline: "center"})
+    this.refs.cardRef.parentNode.scrollTop = this.refs.cardRef.offsetTop - ((1.5) * this.refs.cardRef.offsetHeight);
+    // Using scrollIntoView shifted the page, hiding the header bar in mobile view
+    // this.refs.cardRef.scrollIntoView({block: "end", inline: "center"})
   }
 
   cardClick= (e) => {


### PR DESCRIPTION
Using scrollTop doesn't force the page level scroll to occur. Subtracting (1.5 * offsetHeight) causes the scrolled to item to be in view on both mobile and desktop