### PR TITLE
Fixes category filtering defects

### DIFF
--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -21,7 +21,7 @@ export class CategoryList extends Component {
     let index = selectedCategory.indexOf(selected);
     index !== -1 ? selectedCategory.splice(index, 1) : selectedCategory.push(selected);
     let filteredResource = this.props.resource.filter(resource => {
-      return this.state.selectedCategory.indexOf(resource.categoryautosortscript) > -1;
+      return this.state.selectedCategory.some(searchCategory => resource.categoryautosortscript.split(',').includes(searchCategory));
     });
     this.props.actions.filterByCategories(selectedCategory.length > 0 ? filteredResource : this.props.resource);
   }


### PR DESCRIPTION
* Category filter cannot find Resource with more than 1 category (https://github.com/codeforboston/communityconnect/issues/146)
* Category does not filter if more than 1 selected

### Before submitting this PR, please use netlify to make sure:
- [ ] ~~The app looks okay on web~~ (It doesn't but not caused by this PR)
- [ ] ~~The app looks okay on phone~~ (It doesn't but not caused by this PR)
- [x] Filter by category still works

### If you might be concerned about these things, also check:
- [ ] The app looks okay in ipad
- [ ] Search still works
