### PR TITLE
Trim categories after split to eliminate whitespace based mismatches.

### DIFF
--- a/src/components/CategoryList.js
+++ b/src/components/CategoryList.js
@@ -21,7 +21,7 @@ export class CategoryList extends Component {
     let index = selectedCategory.indexOf(selected);
     index !== -1 ? selectedCategory.splice(index, 1) : selectedCategory.push(selected);
     let filteredResource = this.props.resource.filter(resource => {
-      return this.state.selectedCategory.some(searchCategory => resource.categoryautosortscript.split(',').includes(searchCategory));
+      return this.state.selectedCategory.some(searchCategory => resource.categoryautosortscript.split(',').map(item => item.trim()).includes(searchCategory));
     });
     this.props.actions.filterByCategories(selectedCategory.length > 0 ? filteredResource : this.props.resource);
   }


### PR DESCRIPTION
(We do this trim & split pattern in a few places, so maybe would be good to move this into a unified function)

Found in this pr: 
https://github.com/codeforboston/communityconnect/pull/152#discussion_r


As a concrete example 
Resource named Just-A-Start has

AFFORDABLE HOUSING
JOB TRAINING AND OPPORTUNITY
TRANSITIONING AND INTEGRATING
it will show up when looking for [AFFORDABLE HOUSING] or [AFFORDABLE HOUSING && JOB TRAINING AND OPPORTUNITY] but will not show up when looking only for [JOB TRAINING AND OPPORTUNITY] because it was trying to match on  “JOB TRAINING AND OPPORTUNITY “ vs “JOB TRAINING AND OPPORTUNITY”

### Before submitting this PR, please use netlify to make sure:
- [ ] The app looks okay on web
- [ ] The app looks okay on phone
- [ ] Filter by category still works

### If you might be concerned about these things, also check:
- [ ] The app looks okay in ipad
- [ ] Search still works
