### PR TITLE
Show cards in admin page in one column instead of two columns on ipad

### DIFF
--- a/src/components/AdminPage/CardGrid.js
+++ b/src/components/AdminPage/CardGrid.js
@@ -70,11 +70,11 @@ export class CardGrid extends Component {
           onSortChange={this.handleSortChange}
           sortOptions={sortOptions}
         /></Col>
-      </Row>              
+      </Row>
           <Row>
             {
               sortedData.map((resource, index) => (
-                <Col key={resource.id} lg="4" sm="6" xs="12">
+                <Col key={resource.id} lg="4" sm="12" xs="12">
                   <OrganizationCard
                       key={resource.id}
                       index={resource.id}


### PR DESCRIPTION
### Before submitting this PR, please use netlify to make sure:
- [ ] The app looks okay on web
- [ ] The app looks okay on phone
- [ ] Filter by category still works

### If you might be concerned about these things, also check:
- [ ] The app looks okay in ipad
- [ ] Search still works
