### PR TITLE
Update header to hide navbar toggle in Mobile View

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -61,19 +61,22 @@ class Header extends Component {
           <NavbarBrand className="Logo" onClick={this.modalOpen}>
             <h3>Community Connect</h3>
           </NavbarBrand>
-          <NavbarToggler onClick={this.toggleNavbar} />
-          <Collapse isOpen={!this.state.collapsed} navbar>
-            <Nav className="ml-auto" navbar>
-              <NavItem>
-                <Route path='/admin' render={props =>
-                  <Button
-                    color="secondary"
-                    onClick={() => this.props.toggleSavedResourcesPane()}>
-                    Saved Resources
-            </Button>} />
-              </NavItem>
-            </Nav>
-          </Collapse>
+          <Route path='/admin' render={props =>
+            <div id="navbar">
+              <NavbarToggler onClick={this.toggleNavbar} />
+              <Collapse isOpen={!this.state.collapsed} navbar>
+                <Nav className="ml-auto" navbar>
+                  <NavItem>
+                    <Button
+                      color="secondary"
+                      onClick={() => this.props.toggleSavedResourcesPane()}>
+                      Saved Resources
+                    </Button>
+                  </NavItem>
+                </Nav>
+              </Collapse>
+            </div>
+          } />
         </Navbar>
         <Modal isOpen={this.state.modal} toggle={this.modalToggle} onClosed={this.toggle}>
           <ModalHeader>Alert</ModalHeader>


### PR DESCRIPTION
This PR addresses the need to hide the navigation toggle button displayed in the mobile view for the the Client view. This navigation toggle is only used in the admin view, so it is not helpful in the client view. This pull request closes #196.

Before, the mobile Client view displayed as below:
![image](https://user-images.githubusercontent.com/9803215/53058496-3bc98980-3481-11e9-8d71-8b4f2e193dda.png)

Now, the mobile Client view displays without the toggle:
![image](https://user-images.githubusercontent.com/9803215/53058538-703d4580-3481-11e9-84b6-73b5a7da0a2f.png)


The mobile Admin view displays with the toggle, still:
![image](https://user-images.githubusercontent.com/9803215/53058521-5ac81b80-3481-11e9-89ec-4d04db4fcb34.png)

