### PR TITLE
Create "Not Found" page for Invalid Requests

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,11 +1,16 @@
 import React from 'react';
-import {Route} from 'react-router';
+import {Route, Switch} from 'react-router';
 
-import AppContainer from './AppContainer'
+import AppContainer from './AppContainer';
+import NotFoundPage from '../components/NotFoundPage/NotFoundPage';
 
 const App = () => (
   <div>
-    <Route path = '/' component={AppContainer} />
+    <Switch>
+      <Route path = '/' exact component={AppContainer} />
+      <Route path = '/admin' exact component={AppContainer} />
+      <Route component={NotFoundPage} />
+    </Switch>
   </div>
 )
 

--- a/src/components/NotFoundPage/NotFoundPage.js
+++ b/src/components/NotFoundPage/NotFoundPage.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Link } from 'react-router-dom'
+import { Button } from 'reactstrap';
+
+import styles from './NotFoundPage.module.css';
+
+const NotFoundPage = ({currentPosition}) => {
+        return (
+            <div className={styles.container}>
+                <div className="error-title">
+                    <h2>Error 404</h2>
+                    <h4>Page Not Found</h4>
+                    <p>
+                        The resource you are trying to access could not be found. 
+                        Navigate back to the Home Page and try again.
+                    </p>
+                    <Button tag={Link} to="/" color="primary">Go Home</Button>{' '}
+                </div>
+            </div>
+        );
+}
+
+export default NotFoundPage;

--- a/src/components/NotFoundPage/NotFoundPage.module.css
+++ b/src/components/NotFoundPage/NotFoundPage.module.css
@@ -1,0 +1,11 @@
+.container {
+    max-width: 500px;
+    padding: 20% 20px 0px 20px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+}


### PR DESCRIPTION
This pull request address #202 and displays a "Not Found" page if an invalid resource is requested. This could be an invalid route, such as `/help` or `/sdlkajsdf`. When an invalid URL is accessed, the router displays the `NotFoundPage` component, which offers the user some insight into what is going on. 

| Desktop View | Mobile View |
| --- | --- | 
| ![localhost_3000_dsfdf](https://user-images.githubusercontent.com/9803215/53060310-02e0e300-3488-11e9-966b-b105f8c6116d.png) | ![localhost_3000_dsfdf iphone 6_7_8](https://user-images.githubusercontent.com/9803215/53060315-096f5a80-3488-11e9-8ea3-9214b7d1c26d.png) |