### PR TITLE
Vk issue 222

### DIFF
--- a/src/components/AdminPage/AdminPage.js
+++ b/src/components/AdminPage/AdminPage.js
@@ -9,7 +9,7 @@ const AdminPage = ({currentPosition}) => {
 
         return (
             <div className={styles.wrapper}>
-                <div>
+                <div style={{overflowY: "scroll"}}>
                 <CategoryList />
                 </div>
                 <CardGrid

--- a/src/components/AdminPage/CardGrid.js
+++ b/src/components/AdminPage/CardGrid.js
@@ -60,7 +60,7 @@ export class CardGrid extends Component {
     const sortedData = this.state.dataSort();
 
     return (
-      <Container>
+      <Container style={{overflowY: "scroll"}}>
       <Row>
         <Col>
         <SearchBar

--- a/src/components/AdminPage/CategoryList.module.css
+++ b/src/components/AdminPage/CategoryList.module.css
@@ -5,5 +5,5 @@
 .Form {
   /* position: sticky; */
   top: 0px;
-  overflow-y: scroll;
+  /* overflow-y: scroll; */
 }

--- a/src/components/AdminPage/CategoryList.module.css
+++ b/src/components/AdminPage/CategoryList.module.css
@@ -3,7 +3,5 @@
 }
 
 .Form {
-  /* position: sticky; */
   top: 0px;
-  /* overflow-y: scroll; */
 }

--- a/src/components/AdminPage/CategoryList.module.css
+++ b/src/components/AdminPage/CategoryList.module.css
@@ -3,7 +3,7 @@
 }
 
 .Form {
- position: sticky;
- top: 0px;
- overflow: scroll;
+  /* position: sticky; */
+  top: 0px;
+  overflow-y: scroll;
 }

--- a/src/components/AdminPage/CategoryList.module.css
+++ b/src/components/AdminPage/CategoryList.module.css
@@ -5,4 +5,5 @@
 .Form {
  position: sticky;
  top: 0px;
+ overflow: scroll;
 }


### PR DESCRIPTION
### Before submitting this PR, please use netlify to make sure:
- [ ] The app looks okay on web
- [ ] The app looks okay on phone
- [ ] Filter by category still works

### If you might be concerned about these things, also check:
- [ ] The app looks okay in ipad
- [ ] Search still works

I've commented-out position: sticky and added overflow-y: scroll to CategoryList.module.css.  This doesn't fix it perfectly, and I think overflow-y doesn't matter too much.  Getting rid of position: sticky seems to be allowing the category list to scroll in tandem with the organization cards.  I think the problem has to do with the div surrounding both the category list and the organization cards.  I definitely do NOT want to mess with that because I'm new to project and I don't want to screw up everyone else's hard work.  I think what I've done with that single css file will allow for at least a little better scrolling as a temporary fix.  I have some thoughts for the div structure that I can share on Tuesday (March 5).
