### PR TITLE
put badge on same line for save button

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -88,8 +88,7 @@ class Header extends Component {
                     <Button
                       className={this.btnColor()}
                       onClick={() => this.props.toggleSavedResourcesPane()}>
-                      Saved Resources
-                      {this.btnBadge()}
+                      Saved Resources {this.btnBadge()}
                     </Button>
                   </NavItem>
                 </Nav>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -2,11 +2,13 @@
     position: absolute;
     right: 11px;
     top: 11px;
+    width: 200px;
 }
 
 .header__saved-resources--blue {
     background-color: #007ea3;
     border-color: #007ea3;
+    width: 100%;
 }
 
 .header__saved-resources--blue:focus {
@@ -25,11 +27,9 @@
 }
 
 .header__saved-resources--count {
-    width: 15%;
     margin-left: 2%;
     border: 1px solid white;
-
     font-weight: 100;
-
     background-color: #007ea3;
+    display: inline;
 }


### PR DESCRIPTION
I adjusted the CSS so that the badge is on the same line as the text in the button.

This is what it looks like on `master` right now (broken):

![image](https://user-images.githubusercontent.com/13875792/53597093-449c1880-3b6f-11e9-8ebe-a4551274160a.png)

This is what it looks like on this branch:

![image](https://user-images.githubusercontent.com/13875792/53597261-b7a58f00-3b6f-11e9-83b0-76edb8282053.png)

Does this look like what we want?

### Before submitting this PR, please use netlify to make sure:
- [ x ] The app looks okay on web
- [ x ] The app looks okay on phone
- [ x ] Filter by category still works

### If you might be concerned about these things, also check:
- [ x ] The app looks okay in ipad
- [ x ] Search still works
