### PR TITLE
Ensure that header and page height add to 100%

### DIFF
--- a/src/App/App.module.css
+++ b/src/App/App.module.css
@@ -9,7 +9,7 @@
 .header {
   top: 0;
   width: 100%;
-  height: auto;
+  height: 63px;
   padding: 1px;
 }
 

--- a/src/components/MapPage/MapPage.module.css
+++ b/src/components/MapPage/MapPage.module.css
@@ -2,8 +2,8 @@
   #container {
     position: absolute;
     width: 100%;
-    /* 55px is the height of the header*/
-    height:calc(100% - 55px); 
+    /* 63px is the height of the header*/
+    height:calc(100% - 63px); 
     z-index: 0;
   }
     .staticPane {


### PR DESCRIPTION
Minor changes to ensure that the header is 63px high and page height is 100%-63px.

Previously the header height was auto but page height assumed a fixed header height of 55px, which caused the content to be slightly taller than the page on most browsers, creating an unnecessary scroll bar.

Fixes #310 