### PR TITLE
Change categoryautosortscript to category

### DIFF
--- a/src/api/googlesheetApi.js
+++ b/src/api/googlesheetApi.js
@@ -11,6 +11,7 @@ function normalizeHeaders(element) {
   if (element["latitude"] && element["longitude"]) {
     element["coordinates"] = { lat: parseFloat(element["latitude"]), lng: parseFloat(element["longitude"]) }
   }
+  element["category"] = element["category"] || element["categoryautosortscript"];
 
   if (element.city || element.address || element.state || element.zipcode) {
     element.location = element["combinedaddress"];

--- a/src/components/AdminPage/CategoryList.js
+++ b/src/components/AdminPage/CategoryList.js
@@ -20,7 +20,7 @@ export class CategoryList extends Component {
     let index = selectedCategory.indexOf(selected);
     index !== -1 ? selectedCategory.splice(index, 1) : selectedCategory.push(selected);
     let filteredResource = this.props.resource.filter(resource => {
-      return this.state.selectedCategory.some(searchCategory => resource.categoryautosortscript.split(',').map(item => item.trim()).includes(searchCategory));
+      return this.state.selectedCategory.some(searchCategory => resource.category.split(',').map(item => item.trim()).includes(searchCategory));
     });
     this.props.actions.filterByCategories(selectedCategory.length > 0 ? filteredResource : this.props.resource);
   }

--- a/src/components/Common/OrganizationCard.js
+++ b/src/components/Common/OrganizationCard.js
@@ -58,7 +58,7 @@ class OrganizationCard extends Component {
     render() {
         const {
             name,
-            categoryautosortscript,
+            category,
             overview,
             location,
             website,
@@ -89,7 +89,7 @@ class OrganizationCard extends Component {
                     <OrganizationCardHeaderText>{name}</OrganizationCardHeaderText>
                 </OrganizationCardHeader>
                 <OrganizationCardBody
-                    categoryautosortscript={categoryautosortscript}
+                    category={category}
                     distance={distance}
                     location={location}
                     directionUrl={directionUrl}
@@ -134,7 +134,7 @@ const OrganizationCardSocialMediaLink = ({ url, icon, title }) => (
 );
 
 const OrganizationCardBody = ({
-    categoryautosortscript,
+    category,
     distance,
     location,
     directionUrl,
@@ -144,7 +144,7 @@ const OrganizationCardBody = ({
     children
 }) => (
     <OrganizationCardBodyWrapper>
-        <OrganizationCardSubtitle>{categoryautosortscript}</OrganizationCardSubtitle>
+        <OrganizationCardSubtitle>{category}</OrganizationCardSubtitle>
         {
             distance && <p>Distance from your location: {distance} miles</p>
         }

--- a/src/components/SavedResources/SavedResource.js
+++ b/src/components/SavedResources/SavedResource.js
@@ -65,7 +65,7 @@ class SavedResource extends Component {
     const {
       id,
       name,
-      categoryautosortscript,
+      category,
       overview,
       location,
       website,
@@ -99,7 +99,7 @@ class SavedResource extends Component {
               -
             </span>
             <CardSubtitle className={styles.CardBody_CardSubtitle}>
-              {categoryautosortscript}
+              {category}
             </CardSubtitle>
             {distance &&
               <div>{distanceElement}</div>}

--- a/src/reducers/resourceReducer.js
+++ b/src/reducers/resourceReducer.js
@@ -27,7 +27,7 @@ export function categories(state = initialState.categories, action) {
         case types.LOAD_RESOURCE_DATA_SUCCESS:
             const categories = {};
             for (let data of action.resource) {
-                let category = data.categoryautosortscript.split(',');
+                let category = data.category.split(',');
                 category.forEach(cat => categories[cat] = cat.trim());
             }
             const categoryList = [...(new Set(Object.values(categories)))];


### PR DESCRIPTION
Changes name of resource from Column D of spreadsheet from "categoryautosortscript" to "category". Backward-compatible, so it will work on spreadsheets with either "Category" or "Category (Autosort Script)" in Column D.
Here's a test: I made a copy of the resources page, with Column D renamed to "Category". The resource is named "hodor". So, if you go to https://communityconnect.netlify.com/hodor, you'll be trying to read my renamed column with the current master branch, and you'll see a progress circle forever. Whereas running the category-name branch on http://localhost:3000/hodor, the app works. It also works on localhost:3000/revere.

### Before submitting this PR, please use netlify to make sure:
- [ ] The app looks okay on web
- [ ] The app looks okay on phone
- [ ] Filter by category still works

### If you might be concerned about these things, also check:
- [ ] The app looks okay in ipad
- [ ] Search still works
