### PR TITLE
deploying again (#343)

### DIFF
--- a/src/App/AppContainer.js
+++ b/src/App/AppContainer.js
@@ -128,7 +128,7 @@ class AppContainer extends Component {
                     {(!isFetchingResource) &&
                         <div>
                             <Route exact path='/:resource/admin' render={(props) => <AdminPage currentPosition={this.state.position} />} />
-                            <Route exact path='/:resource/' render={(props) => <MapPage currentPosition={this.state.position} />} />
+                            <Route exact path='/:resource/' render={(props) => <MapPage currentPosition={this.state.position} displayFeedbackLink={this.state.displayFeedbackLink} />} />
                             <SplitScreenTogglePane isOpen={this.state.isSavedResourcePaneOpen}>
                                 <SavedResourcePanel resourcePath={this.props.match.params.resource} />
                             </SplitScreenTogglePane>

--- a/src/components/Common/SortBar.js
+++ b/src/components/Common/SortBar.js
@@ -14,14 +14,15 @@ class SortBar extends React.Component {
 
     render() {
         return (
-            <select name="cardSort" onChange={this.handleClick}>
-                <option value="">Select a sort</option>
-                {this.props.sortOptions.map((sortOption, i) =>
-                    <option key={sortOption.key} value={i} disabled={sortOption.disabled}>
-                        {sortOption.key}
-                    </option>
-                )}
-            </select>
+            <span><b>Sort by: </b>
+                <select name="cardSort" onChange={this.handleClick}>
+                    {this.props.sortOptions.map((sortOption, i) =>
+                        <option key={sortOption.key} value={i} disabled={sortOption.disabled}>
+                            {sortOption.key}
+                        </option>
+                    )}
+                </select>
+            </span>
         );
     }
 }

--- a/src/components/MapPage/MapPage.js
+++ b/src/components/MapPage/MapPage.js
@@ -9,7 +9,7 @@ import { SplitScreenSlidingPane } from './SplitScreenSlidingPane';
 class MapPage extends Component {
  render() {
     return (
-        <div id={styles.container}>
+        <div id={this.props.displayFeedbackLink ? styles.containerfooter : styles.container}>
           <SplitScreenSlidingPane>
               <ResultList
                 ref={instance => { this.resultListItem = instance }}

--- a/src/components/MapPage/MapPage.module.css
+++ b/src/components/MapPage/MapPage.module.css
@@ -1,9 +1,19 @@
-
   #container {
     position: absolute;
     width: 100%;
     /* 63px is the height of the header*/
     height:calc(100% - 63px); 
+    margin-bottom: 0px;
+    z-index: 0;
+  }
+  
+  #containerfooter {
+    position: absolute;
+    width: 100%;
+    /* 63px is the height of the header, 67px is the height of the footer*/
+    height:calc(100% - 63px - 67px); 
+    margin-bottom: 67px;
+
     z-index: 0;
   }
     .staticPane {

--- a/src/components/MapPage/ResultList.js
+++ b/src/components/MapPage/ResultList.js
@@ -73,7 +73,7 @@ export class ResultList extends Component {
 
   render() {
     const sortOptions = [
-      { key: 'Alphabetically', sort: this.sortByAlphabet, disabled: false }
+      { key: 'A-Z', sort: this.sortByAlphabet, disabled: false }
       , { key: 'Distance', sort: this.sortByDistance, disabled: !this.props.currentPos }
     ];
 


### PR DESCRIPTION
* Update README.md

* For backwards compatibility, /admin should redirect to /revere/admin (#305)

* Ensure that header and page height add to 100% (#312)

* Did some basic "boyscouting", deleted a lot of unused/commented code (#318)

Basic housekeeping stuff. Part of my effort to clean up and refactor the code according to this guide: https://dev.to/gonedark/10-practices-for-readable-code-143a . This addresses the first two points, code formatting and deleting dead code. Also followed some "boyscouting" guidelines seen here: https://jasonmccreary.me/articles/are-you-a-boy-scout//

* Show cursor pointer for </a>

* Notfoundpage #306 (#311)

* fix(error-page): implement NotFoundPage on 404

remove console log

show NotFoundPage on correct path but wrong route => revere/dewdfewfwf returns NotFoundPage

fix(notfoundpage): fix app rendering notfound on all resource pages

fix(404-page): fix 404 on pages not found

* fix(AppContainer): handle 404

* fix(404): disabled 404 on :resource/admin page

* Change categoryautosortscript to category (#324)

* Bump macaddress from 0.2.8 to 0.2.9 (#322)

Bumps [macaddress](https://github.com/scravy/node-macaddress) from 0.2.8 to 0.2.9.
- [Release notes](https://github.com/scravy/node-macaddress/releases)
- [Commits](https://github.com/scravy/node-macaddress/compare/0.2.8...0.2.9)

Signed-off-by: dependabot[bot] <support@github.com>

* Rename category column (#332)

* Change categoryautosortscript to category

* Change "category" to "categories"

* fixed categories label bug. (#333)

* fixed categories label bug.

* added legacy capability with category autosortscript so it works with MSM and other test templates.
once we merge development and master, we will change the revere sheet column D to "Categories", so we can still demo the master branch without too many problems.

* Updated readme with admin/client views

Explained basic differences btw admin/client views and provided example links

* Update README.md

fixed enumerating list

* Sorting selection box improvements (#320)

* Make footer displace main page instead of drawing over it (#336)

* Make footer displace main page instead of drawing over it

* Remove experimental code

### Before submitting this PR, please use netlify to make sure:
- [ ] The app looks okay on web
- [ ] The app looks okay on phone
- [ ] Filter by category still works

### If you might be concerned about these things, also check:
- [ ] The app looks okay in ipad
- [ ] Search still works
