### PR TITLE
feat: Make the add-resource button into a toggle

### DIFF
--- a/src/components/Common/OrganizationCard.js
+++ b/src/components/Common/OrganizationCard.js
@@ -35,9 +35,8 @@ class OrganizationCard extends Component {
     }
 
     saveItem = () => {
-        if (!this.state.saveExist) {
-            this.props.actions.addSavedResource(this.props.organization);
-        }
+        this.props.actions.addSavedResource(this.props.organization);
+        
         const query = qs.parse(window.location.search.replace('?', ''));
         let resources = [];
 
@@ -54,6 +53,35 @@ class OrganizationCard extends Component {
             pathname: window.location.pathname,
             search: `?resources=${resources.join(',')}`,
         });
+    }
+
+    removeItem = () => {
+        // code copied verbatim from SavedResource.removalConfirmed()
+        // should probably refactor for cleanliness
+        const query = qs.parse(window.location.search.replace('?', ''));
+        let resources = [];
+        if (query.resources) {
+            resources = query.resources.split(',');
+        }
+        const indexOfResource = resources.indexOf(this.props.organization.id);
+
+        if (this.props.savedResource.some(resource => resource.id === this.props.organization.id)) {
+            this.props.actions.removeSavedResource(this.props.organization.id);
+            resources.splice(indexOfResource, 1);
+        }
+        this.props.history.push({
+            pathname: window.location.pathname,
+            search: `?resources=${resources.join(',')}`,
+        });
+    }
+
+    toggleItem = () => {
+        // if saved, remove. otherwise, save
+        if (this.state.saveExist) {
+            this.removeItem();
+        } else {
+            this.saveItem();
+        }
     }
 
     render() {
@@ -84,7 +112,7 @@ class OrganizationCard extends Component {
                     {
 
                         this.props.saveable
-                            ? <OrganizationCardSaveButton saveItem={this.saveItem} saveExist={this.state.saveExist} />
+                            ? <OrganizationCardSaveButton saveItem={this.toggleItem} saveExist={this.state.saveExist} />
                             : null
                     }
                     <OrganizationCardHeaderText>{name}</OrganizationCardHeaderText>


### PR DESCRIPTION
<!--

👋 Thanks for submitting a PR!
A good pull request goes a long way. Before submitting this pull request, please make sure you can check the following boxes:
- [ ] If this is a UI change, I have tested the change in mobile, tablet, and desktop viewports
- [ ] I have performed a self-review of my own code
- [ ] I have selected a title that summarizes my fix
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.

Next, fill out the following sections:

-->

## Description
<!-- A description of the change and which issue or behavior is addressed.                      -->
Makes the Add Resource button on the OrganizationCard into a toggle button, so clicking it on a resource that has already been added will remove it from Saved Resources.
<!-- Is this a UI change? If so, include screenshots!                                           -->

Fixes #329
<!-- This project only accepts pull requests related to open issues. If an issue does not exist -->
<!-- for this change, please check out our guide at CONTRIBUTING.md to create one.              -->

## Motivation and Context
<!-- Answering the question, "why is this change necessary?" or "what problem does it solve?"   -->
This fix was previously attempted with #347, then corrected by #361. Which broke the app, and was then hurriedly fixed with #362, both of which were then removed by #363. Unlike the previous versions, this PR was made from the correct branch, and therefore makes exactly the number of changes I intended to make. Also, it does not break the app.
## Type of change
<!-- Delete any of the following that do not apply, and put an `x` where it does!               -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
